### PR TITLE
Fix button hover states and rate-limit error

### DIFF
--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -5,11 +5,11 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none group/button select-none",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        default: "bg-primary text-primary-foreground hover:bg-primary/90 active:bg-primary/80",
         outline: "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",

--- a/frontend/lib/auth-errors.ts
+++ b/frontend/lib/auth-errors.ts
@@ -13,14 +13,16 @@ const ERROR_MAP: Record<string, string> = {
     "Password must be at least 6 characters.",
   "Unable to validate email address: invalid format":
     "Please enter a valid email address.",
-
-  // Rate limiting
-  "For security purposes, you can only request this after 60 seconds.":
-    "Too many attempts. Please wait a moment and try again.",
 };
+
+// Supabase rate-limit messages include a variable countdown
+// ("...after 57 seconds", "...after 42 seconds") so exact match won't work.
+const RATE_LIMIT_PATTERN = /you can only request this after \d+ seconds/i;
+const RATE_LIMIT_MSG = "Too many attempts. Please wait a moment and try again.";
 
 const DEFAULT_ERROR = "Something went wrong. Please try again.";
 
 export function mapAuthError(rawMessage: string): string {
+  if (RATE_LIMIT_PATTERN.test(rawMessage)) return RATE_LIMIT_MSG;
   return ERROR_MAP[rawMessage] ?? DEFAULT_ERROR;
 }


### PR DESCRIPTION
## Summary

- **Button hover fix** — Nova template's default variant used `[a]:hover` (attribute selector that only targets anchors), leaving `<button>` elements with no visual hover feedback. Added `hover:bg-primary/90`, `active:bg-primary/80`, and `cursor-pointer`
- **Rate-limit error fix** — Supabase rate-limit messages include a variable countdown ("after 57 seconds", "after 42 seconds"). Our exact string match only caught "after 60 seconds". Switched to regex pattern matching

## Test plan

- [ ] Hover over "Create Account" and social login buttons — should darken on hover
- [ ] Click buttons — should darken further on press (active state)
- [ ] Cursor should change to pointer on button hover
- [ ] Rapidly submit signup form twice — should show "Too many attempts" instead of "Something went wrong"

🤖 Generated with [Claude Code](https://claude.com/claude-code)