### PR TITLE
Fix Vercel build warnings

### DIFF
--- a/.claude/reference/userjourney.md
+++ b/.claude/reference/userjourney.md
@@ -51,9 +51,21 @@
   tree, tech stack, known issues, deployment status),
   project-info.md (Vercel now live), vision.md (build status),
   README.md (full rewrite with current structure and versions)
+- **Bug fixes** — Fixed Supabase rate-limit error matching
+  (regex instead of exact string since countdown varies);
+  fixed button hover states (`[a]:hover` Nova bug — buttons
+  had no hover; added `hover:bg-primary/90`, `active`,
+  `cursor-pointer`); confirmed by reading Supabase auth logs
+- **Landing bird image** — Moved `landing_bird.png` to
+  `frontend/public/images/`; replaced placeholder.svg on
+  both login and signup image panels
+- **Supabase redirect URLs** — Configured `oparax.com` in
+  Supabase → Authentication → URL Configuration →
+  Redirect URLs; also updated Site URL
+- **NOTES.md** — User created brain dump file for low-priority
+  bugs and feature ideas; added reference to CLAUDE.md
 
 ### What's remaining
 
-- **Agentic workflow UI** — Continue work on the
-  `ft/3-agentic-workflow-ui` branch: build out the
-  agentic workflow interface with shadcn components
+- **Button feedback** — Buttons still lack sufficient visual
+  feedback on click/hover per user notes; revisit styling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ oparax-chirp/
 │       ├── project-info.md        # Accounts, env vars, commands, setup
 │       └── userjourney.md         # Session log — what was done, what's next
 ├── CLAUDE.md                      # This file
+├── NOTES.md                       # Brain dump — low-priority bugs & feature ideas
 ├── pyproject.toml                 # Python config
 └── .env                           # API credentials (git-ignored)
 ```
@@ -89,6 +90,7 @@ oparax-chirp/
 | `.claude/reference/vision.md` | Product vision, core loop, long-term direction |
 | `.claude/reference/project-info.md` | Accounts, env vars, API setup, dev commands |
 | `.claude/reference/userjourney.md` | Start of session (context), end of session (update) |
+| `NOTES.md` | Low-priority bugs and feature ideas noticed by the user (brain dump, not urgent) |
 
 ## Rules
 
@@ -123,8 +125,6 @@ oparax-chirp/
   Need client-side check.
 - **Email confirmation template**: Must point to
   `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email`
-- **Supabase redirect URLs**: `oparax.com` must be added to
-  Supabase → Authentication → URL Configuration → Redirect URLs
 - **Proxy route protection**: Currently page-level only
   (`dashboard/page.tsx`). Should add proxy-level redirect.
 - **Social login buttons**: Apple, Google, X buttons render

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,35 @@
+# Supabase
+- Supabase URL configuration (https://supabase.com/dashboard/project/pcgvpypzfwuchyfwdlwe/auth/url-configuration) Site URL relinks to normal oparax.com URL we have to link it to an error page if nothing found
+
+# Frontend UI
+- Sign Up/ Sign in Button Feedback: Currently, the signup button shows no reaction when clicked (no shadow or color change). This lack of visual confirmation leads to accidental double-clicking, therefore generally all button UIs/UX has to be changed to have it change colors on hover, some anumation upon press, show a loading thing upon succesful press when waiting on server response for understandable ui
+
+- Sign up double click errors: Double-clicking the sign up button in that confusion described above throws some sort of an error. It links to some error page. 
+
+- Uniform Interaction: Hover and click states need to be applied uniformly across all buttons. The current hover shadow is too faint; a distinct color change is needed to clearly denote interaction.
+
+- Loading State: There is no indication of a successful click or background processing. A loading indicator should appear on the button after it is pressed to signal that the server is returning a result.
+
+# Vercel 
+- On each deployment, when we merge to main and the deployment gets triggered on Vercel, we witness these three warnings in yellow, The big warning block and then the line starting with both, with the alert symbol before them in the output during deployment. Might as well just take care of these warnings. Why do these occur anyways:
+
+```
+╭ Warning ─────────────────────────────────────────────────────────────────────╮
+│                                                                              │
+│   Ignored build scripts: esbuild@0.27.3, msw@2.12.10.                        │
+│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
+│   to run scripts.                                                            │
+│                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+Done in 1.5s using pnpm v10.28.0
+Detected Next.js version: 16.1.6
+Running "pnpm run build"
+> frontend@0.1.0 build /vercel/path0/frontend
+> next build
+⚠ Both `outputFileTracingRoot` and `turbopack.root` are set, but they must have the same value.
+Using `outputFileTracingRoot` value: /vercel/path0.
+▲ Next.js 16.1.6 (Turbopack)
+  Creating an optimized production build ...
+⚠ Both `outputFileTracingRoot` and `turbopack.root` are set, but they must have the same value.
+Using `outputFileTracingRoot` value: /vercel/path0.
+```

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,12 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  turbopack: {
-    // The monorepo root has a package-lock.json that confuses Turbopack's
-    // workspace root detection. Pin the root to frontend/ so it resolves
-    // dependencies (like tailwindcss) from the correct node_modules.
-    root: process.cwd(),
-  },
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,9 @@
     "react-dom": "19.2.3",
     "tailwind-merge": "^3.5.0"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild", "msw"]
+  },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## Summary

- **Turbopack root warning** — Removed `turbopack.root` workaround from `next.config.ts`. The stale root `package-lock.json` that originally caused Turbopack's workspace detection to break is gone, so the workaround is no longer needed. Eliminates the `"Both outputFileTracingRoot and turbopack.root are set"` warning
- **pnpm build scripts warning** — Added `pnpm.onlyBuiltDependencies` for `esbuild` and `msw` in `package.json`. Eliminates the `"Ignored build scripts"` warning
- **NOTES.md** — Added user's brain dump file for low-priority bugs/features, referenced in CLAUDE.md

## Test plan

- [ ] Vercel deployment completes without the three yellow warnings
- [ ] Site still loads correctly at oparax.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)