### PR TITLE
Sprint 1 · Foundation — DS component classes (#22)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -503,6 +503,210 @@
     z-index: 200;
     opacity: 0;
   }
+
+  /* ------------------------------------------------ app sidebar (nav + footer) */
+  .nav-main {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    height: 44px;
+    padding: 0 10px;
+    border-radius: var(--radius);
+    border: 1px solid transparent;
+    color: var(--muted);
+    font: 600 0.9375rem/1 var(--font-sans);
+    text-decoration: none;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s;
+  }
+  .nav-main:hover { background: oklch(1 0 0 / 0.07); color: var(--fg); }
+  .nav-main[data-active="true"] {
+    background: var(--accent-soft);
+    border-color: var(--accent-line);
+    color: var(--accent);
+    font-weight: 650;
+  }
+  .nav-main.nav-soon { opacity: 0.38; cursor: not-allowed; }
+  .nav-main.nav-soon:hover { background: transparent; color: var(--muted); }
+
+  /* settings sub-nav — shallow indent, neutral (not accent) active highlight */
+  .snav { display: flex; flex-direction: column; gap: 1px; padding: 3px 0 6px; }
+  .snav-item {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    height: 32px;
+    padding: 0 10px;
+    margin-left: 14px;
+    border-radius: 7px;
+    color: var(--faint);
+    font: 500 0.84375rem/1 var(--font-sans);
+    text-decoration: none;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s;
+  }
+  .snav-item:hover { background: oklch(1 0 0 / 0.05); color: var(--fg); }
+  .snav-item[data-active="true"] { background: oklch(1 0 0 / 0.09); color: var(--fg); font-weight: 650; }
+
+  /* footer profile line (avatar + name) + icon-only sign out */
+  .you-line {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+    min-width: 0;
+    padding: 8px 10px;
+    border-radius: 9px;
+    background: transparent;
+    border: 0;
+    text-align: left;
+    cursor: pointer;
+    transition: background 0.12s;
+  }
+  .you-line:hover { background: oklch(1 0 0 / 0.06); }
+  .foot-signout {
+    width: 32px;
+    height: 32px;
+    flex: none;
+    display: grid;
+    place-items: center;
+    background: transparent;
+    border: 0;
+    border-radius: 7px;
+    color: var(--faint);
+    cursor: pointer;
+    padding: 0;
+    transition: background 0.12s, color 0.12s;
+  }
+  .foot-signout:hover { background: oklch(0.7 0.185 25 / 0.13); color: var(--err); }
+
+  /* ------------------------------------------------ settings page (section cards + fields) */
+  .card-sec {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 22px 24px;
+    box-shadow: 0 1px 2px oklch(0 0 0 / 0.4);
+  }
+  .sec-title { margin: 0 0 16px; font: 700 1.25rem/1.15 var(--font-sans); letter-spacing: -0.01em; color: var(--fg); }
+
+  /* stacked, labelled settings field (label above input) */
+  .fld { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+  .fld label { font: 650 0.8125rem/1 var(--font-sans); color: var(--muted); }
+  .set-input {
+    width: 100%;
+    height: var(--ctl-h);
+    background: var(--field-bg);
+    border: 1px solid var(--field-line);
+    border-radius: var(--radius);
+    padding: 0 12px;
+    font: 500 0.875rem/1.45 var(--font-sans);
+    color: var(--fg);
+    outline: none;
+    transition: border-color 120ms ease, background 120ms ease;
+  }
+  .set-input:focus { border-color: var(--accent-line); background: var(--field-focus); }
+  .set-input::placeholder { color: var(--faint); font-weight: 400; }
+
+  /* large click-to-upload avatar (hover reveals camera overlay) */
+  .avatar-up {
+    position: relative;
+    width: 88px;
+    height: 88px;
+    border-radius: 50%;
+    flex: none;
+    cursor: pointer;
+    overflow: hidden;
+    box-shadow: inset 0 0 0 1px oklch(1 0 0 / 0.22);
+  }
+  .avatar-up .ov {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: oklch(0 0 0 / 0.5);
+    color: #fff;
+    opacity: 0;
+    transition: opacity 0.16s ease;
+  }
+  .avatar-up:hover .ov { opacity: 1; }
+
+  /* inset settings list row (password, notification, delete, etc.) */
+  .arow {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 13px 15px;
+    background: var(--inset);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+  }
+  .arow .grow { flex: 1; min-width: 0; }
+  .arow .rt { font: 650 0.9375rem/1.2 var(--font-sans); color: var(--fg); }
+  .arow .rs { font: 400 0.8125rem/1.3 var(--font-sans); color: var(--faint); margin-top: 3px; }
+
+  /* neutral outline button (settings actions) */
+  .ghost-btn { background: transparent; border: 1px solid var(--field-line); color: var(--muted); }
+  .ghost-btn:hover { border-color: var(--line-strong); color: var(--fg); transform: none; box-shadow: none; }
+
+  /* ------------------------------------------------ connection pill (logo fills left square, body flush right) */
+  .pill {
+    display: inline-flex;
+    align-items: stretch;
+    border: 1px solid var(--field-line);
+    border-radius: 3px;
+    overflow: hidden;
+    background: var(--chrome);
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    transition: border-color 0.12s;
+  }
+  .pill:hover { border-color: var(--line-strong); }
+  .pill[data-soon="true"] { opacity: 0.45; cursor: default; }
+  .pill[data-soon="true"]:hover { border-color: var(--field-line); }
+  .pill-logo {
+    width: 34px;
+    height: 34px;
+    flex: none;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+    font: 800 1.05rem/1 var(--font-sans);
+  }
+  .pill-logo svg { display: block; width: 34px; height: 34px; }
+  .pill-body {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 13px;
+    color: var(--fg);
+    font: 650 0.84375rem/1 var(--font-sans);
+    white-space: nowrap;
+  }
+  .pblink { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+  .pblink.on  { background: var(--live); box-shadow: 0 0 6px var(--live); animation: dot-blink 1.4s ease-in-out infinite; }
+  .pblink.off { background: var(--err);  box-shadow: 0 0 6px var(--err);  animation: dot-blink 1.4s ease-in-out infinite; }
+  /* letter logo tile (brand marks shipped as a glyph, e.g. G / O) */
+  .lt { width: 34px; height: 34px; display: grid; place-items: center; font: 800 1.05rem/1 var(--font-sans); }
+
+  /* ------------------------------------------------ toggle switch (instant-save settings) */
+  .switch {
+    width: 42px;
+    height: 24px;
+    border-radius: 999px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 0 3px;
+    flex: none;
+    cursor: pointer;
+    background: var(--field-bg);
+    border: 1px solid var(--field-line);
+    transition: background 0.15s ease;
+  }
+  .switch[data-on="true"] { justify-content: flex-end; background: var(--accent-soft); border-color: var(--accent-line); }
+  .switch .knob { width: 17px; height: 17px; border-radius: 50%; background: var(--fg); flex: none; box-shadow: 0 1px 2px oklch(0 0 0 / 0.4); }
 }
 
 /* ------------------------------------------------ animation */
@@ -512,4 +716,5 @@
 @media (prefers-reduced-motion: reduce) {
   .dot.blink { animation: none; }
   .caret { animation: none; }
+  .pblink.on, .pblink.off { animation: none; }
 }


### PR DESCRIPTION
Closes #22.

Ports the new sidebar / settings / connection-pill / toggle component classes from the Claude Design (settings + sidebar) export into `app/globals.css` `@layer components`. **No page wiring** — this unblocks #23–#26.

### Classes added
- Sidebar: `.nav-main` / `.nav-soon`, `.snav` / `.snav-item`, `.you-line` / `.foot-signout`
- Settings: `.card-sec` / `.sec-title`, `.fld` / `.set-input`, `.avatar-up` / `.ov`, `.arow` / `.grow` / `.rt` / `.rs`, `.ghost-btn`
- Connections + toggle: `.pill` / `.pill-logo` / `.pill-body`, `.pblink`, `.lt`, `.switch` / `.knob`

### Notes
- Tokens unchanged (same pure-black/graphite system). `.pblink` reuses the existing `dot-blink` keyframe and is added to the `prefers-reduced-motion` guard.
- `.fld`/`.set-input` overlap conceptually with the repo's `.field`/`ws-input`; dedup deferred to #24 per the plan.

### Verification
- `pnpm build` ✅ · `pnpm lint` ✅ (no issues)
- Visual: throwaway preview route screenshotted via browser-agent — all classes render (accent nav active, dimmed soon, neutral sub-nav, graphite section card, ON toggle, 3 pill states, ghost button), then removed.
- No selector collisions: every new class name is unique across all CSS files.

Spec: `docs/superpowers/specs/2026-06-14-new-ui-sprint-design.md`
Plan: `docs/superpowers/plans/2026-06-14-foundation-ds-classes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)