### PR TITLE
Sprint 5 · Redesign scan + agent-detail pages on the design system (#26)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -503,6 +503,210 @@
     z-index: 200;
     opacity: 0;
   }
+
+  /* ------------------------------------------------ app sidebar (nav + footer) */
+  .nav-main {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    height: 44px;
+    padding: 0 10px;
+    border-radius: var(--radius);
+    border: 1px solid transparent;
+    color: var(--muted);
+    font: 600 0.9375rem/1 var(--font-sans);
+    text-decoration: none;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s;
+  }
+  .nav-main:hover { background: oklch(1 0 0 / 0.07); color: var(--fg); }
+  .nav-main[data-active="true"] {
+    background: var(--accent-soft);
+    border-color: var(--accent-line);
+    color: var(--accent);
+    font-weight: 650;
+  }
+  .nav-main.nav-soon { opacity: 0.38; cursor: not-allowed; }
+  .nav-main.nav-soon:hover { background: transparent; color: var(--muted); }
+
+  /* settings sub-nav — shallow indent, neutral (not accent) active highlight */
+  .snav { display: flex; flex-direction: column; gap: 1px; padding: 3px 0 6px; }
+  .snav-item {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    height: 32px;
+    padding: 0 10px;
+    margin-left: 14px;
+    border-radius: 7px;
+    color: var(--faint);
+    font: 500 0.84375rem/1 var(--font-sans);
+    text-decoration: none;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s;
+  }
+  .snav-item:hover { background: oklch(1 0 0 / 0.05); color: var(--fg); }
+  .snav-item[data-active="true"] { background: oklch(1 0 0 / 0.09); color: var(--fg); font-weight: 650; }
+
+  /* footer profile line (avatar + name) + icon-only sign out */
+  .you-line {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+    min-width: 0;
+    padding: 8px 10px;
+    border-radius: 9px;
+    background: transparent;
+    border: 0;
+    text-align: left;
+    cursor: pointer;
+    transition: background 0.12s;
+  }
+  .you-line:hover { background: oklch(1 0 0 / 0.06); }
+  .foot-signout {
+    width: 32px;
+    height: 32px;
+    flex: none;
+    display: grid;
+    place-items: center;
+    background: transparent;
+    border: 0;
+    border-radius: 7px;
+    color: var(--faint);
+    cursor: pointer;
+    padding: 0;
+    transition: background 0.12s, color 0.12s;
+  }
+  .foot-signout:hover { background: oklch(0.7 0.185 25 / 0.13); color: var(--err); }
+
+  /* ------------------------------------------------ settings page (section cards + fields) */
+  .card-sec {
+    background: var(--card);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 22px 24px;
+    box-shadow: 0 1px 2px oklch(0 0 0 / 0.4);
+  }
+  .sec-title { margin: 0 0 16px; font: 700 1.25rem/1.15 var(--font-sans); letter-spacing: -0.01em; color: var(--fg); }
+
+  /* stacked, labelled settings field (label above input) */
+  .fld { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+  .fld label { font: 650 0.8125rem/1 var(--font-sans); color: var(--muted); }
+  .set-input {
+    width: 100%;
+    height: var(--ctl-h);
+    background: var(--field-bg);
+    border: 1px solid var(--field-line);
+    border-radius: var(--radius);
+    padding: 0 12px;
+    font: 500 0.875rem/1.45 var(--font-sans);
+    color: var(--fg);
+    outline: none;
+    transition: border-color 120ms ease, background 120ms ease;
+  }
+  .set-input:focus { border-color: var(--accent-line); background: var(--field-focus); }
+  .set-input::placeholder { color: var(--faint); font-weight: 400; }
+
+  /* large click-to-upload avatar (hover reveals camera overlay) */
+  .avatar-up {
+    position: relative;
+    width: 88px;
+    height: 88px;
+    border-radius: 50%;
+    flex: none;
+    cursor: pointer;
+    overflow: hidden;
+    box-shadow: inset 0 0 0 1px oklch(1 0 0 / 0.22);
+  }
+  .avatar-up .ov {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: oklch(0 0 0 / 0.5);
+    color: #fff;
+    opacity: 0;
+    transition: opacity 0.16s ease;
+  }
+  .avatar-up:hover .ov { opacity: 1; }
+
+  /* inset settings list row (password, notification, delete, etc.) */
+  .arow {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 13px 15px;
+    background: var(--inset);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+  }
+  .arow .grow { flex: 1; min-width: 0; }
+  .arow .rt { font: 650 0.9375rem/1.2 var(--font-sans); color: var(--fg); }
+  .arow .rs { font: 400 0.8125rem/1.3 var(--font-sans); color: var(--faint); margin-top: 3px; }
+
+  /* neutral outline button (settings actions) */
+  .ghost-btn { background: transparent; border: 1px solid var(--field-line); color: var(--muted); }
+  .ghost-btn:hover { border-color: var(--line-strong); color: var(--fg); transform: none; box-shadow: none; }
+
+  /* ------------------------------------------------ connection pill (logo fills left square, body flush right) */
+  .pill {
+    display: inline-flex;
+    align-items: stretch;
+    border: 1px solid var(--field-line);
+    border-radius: 3px;
+    overflow: hidden;
+    background: var(--chrome);
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    transition: border-color 0.12s;
+  }
+  .pill:hover { border-color: var(--line-strong); }
+  .pill[data-soon="true"] { opacity: 0.45; cursor: default; }
+  .pill[data-soon="true"]:hover { border-color: var(--field-line); }
+  .pill-logo {
+    width: 34px;
+    height: 34px;
+    flex: none;
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+    font: 800 1.05rem/1 var(--font-sans);
+  }
+  .pill-logo svg { display: block; width: 34px; height: 34px; }
+  .pill-body {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 13px;
+    color: var(--fg);
+    font: 650 0.84375rem/1 var(--font-sans);
+    white-space: nowrap;
+  }
+  .pblink { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+  .pblink.on  { background: var(--live); box-shadow: 0 0 6px var(--live); animation: dot-blink 1.4s ease-in-out infinite; }
+  .pblink.off { background: var(--err);  box-shadow: 0 0 6px var(--err);  animation: dot-blink 1.4s ease-in-out infinite; }
+  /* letter logo tile (brand marks shipped as a glyph, e.g. G / O) */
+  .lt { width: 34px; height: 34px; display: grid; place-items: center; font: 800 1.05rem/1 var(--font-sans); }
+
+  /* ------------------------------------------------ toggle switch (instant-save settings) */
+  .switch {
+    width: 42px;
+    height: 24px;
+    border-radius: 999px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 0 3px;
+    flex: none;
+    cursor: pointer;
+    background: var(--field-bg);
+    border: 1px solid var(--field-line);
+    transition: background 0.15s ease;
+  }
+  .switch[data-on="true"] { justify-content: flex-end; background: var(--accent-soft); border-color: var(--accent-line); }
+  .switch .knob { width: 17px; height: 17px; border-radius: 50%; background: var(--fg); flex: none; box-shadow: 0 1px 2px oklch(0 0 0 / 0.4); }
 }
 
 /* ------------------------------------------------ animation */
@@ -512,4 +716,5 @@
 @media (prefers-reduced-motion: reduce) {
   .dot.blink { animation: none; }
   .caret { animation: none; }
+  .pblink.on, .pblink.off { animation: none; }
 }

--- a/app/workspace.css
+++ b/app/workspace.css
@@ -452,10 +452,19 @@
 
 /* agent detail */
 .workspace .ws-stats {
-  display: flex; flex-wrap: wrap; gap: 6px 20px; margin-top: 22px;
-  font: 400 0.875rem/1 var(--font-sans); color: var(--faint);
+  display: grid; grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px; margin-top: 22px;
 }
-.workspace .ws-stats b { color: var(--fg); font-weight: 650; }
+.workspace .ws-stat {
+  display: flex; flex-direction: column; gap: 4px;
+  padding: 13px 16px;
+  background: var(--card); border: 1px solid var(--line); border-radius: 12px;
+}
+.workspace .ws-stat b { font: 700 1.375rem/1.05 var(--font-sans); color: var(--fg); letter-spacing: -0.01em; }
+.workspace .ws-stat span { font: 500 0.8125rem/1 var(--font-sans); color: var(--faint); }
+@media (max-width: 720px) {
+  .workspace .ws-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
 .workspace .ws-settings-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; }
 .workspace .ws-saved-note { font: 500 0.8125rem/1 var(--font-sans); color: var(--live); }
 
@@ -483,12 +492,29 @@
 }
 
 .workspace .ws-item { display: flex; flex-direction: column; gap: 12px; padding: 14px 16px; background: var(--card); border: 1px solid var(--line); border-radius: 10px; }
+.workspace .ws-item-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
 .workspace .ws-item-title { margin: 0; font: 650 1.0625rem/1.4 var(--font-sans); color: var(--fg); }
+.workspace .ws-item-status {
+  display: inline-flex; align-items: center; gap: 7px; flex: none;
+  font: 650 0.75rem/1 var(--font-sans); color: var(--faint);
+  border: 1px solid var(--line); border-radius: 999px;
+  padding: 5px 10px; white-space: nowrap; text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.workspace .ws-item-status .dot { background: var(--faint); }
+.workspace .ws-item-status[data-status="posted"] { color: var(--live); border-color: oklch(0.82 0.16 155 / 0.4); }
+.workspace .ws-item-status[data-status="posted"] .dot { background: var(--live); }
+.workspace .ws-item-status[data-status="failed"] { color: var(--err); border-color: oklch(0.7 0.185 25 / 0.4); }
+.workspace .ws-item-status[data-status="failed"] .dot { background: var(--err); }
 .workspace .ws-item-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
 .workspace .ws-link { font: 400 0.8125rem/1 var(--font-sans); color: var(--accent); }
 .workspace .ws-link:hover { text-decoration: underline; }
 .workspace .ws-item-note { font: 400 0.8125rem/1.4 var(--font-sans); color: var(--faint); }
 .workspace .ws-sources { display: flex; flex-direction: column; gap: 4px; }
+.workspace .ws-sources .ws-link { display: inline-flex; align-items: center; gap: 5px; }
+.workspace .ws-sources .arr { color: var(--accent-vivid); font-weight: 600; }
+.workspace .ws-item-source { display: flex; flex-direction: column; gap: 7px; padding-top: 4px; border-top: 1px solid var(--line); }
+.workspace .ws-item-source-label { font: 650 0.6875rem/1 var(--font-sans); color: var(--faint); text-transform: uppercase; letter-spacing: 0.04em; }
 
 /* settings */
 .workspace .ws-tabs { display: flex; gap: 2px; border-bottom: 1px solid var(--line); margin-top: 22px; }

--- a/components/loop/agent-detail.tsx
+++ b/components/loop/agent-detail.tsx
@@ -541,18 +541,22 @@ export function AgentDetail({
   return (
     <div className="ws-create">
       <div className="ws-stats">
-        <span>
-          <b>{runs.length}</b> scans
-        </span>
-        <span>
-          <b>{totalItems}</b> drafts
-        </span>
-        <span>
-          <b>{postedItems}</b> posted
-        </span>
-        <span>
-          <b>{formatCost(totalCost)}</b> total cost
-        </span>
+        <div className="ws-stat">
+          <b>{runs.length}</b>
+          <span>scans</span>
+        </div>
+        <div className="ws-stat">
+          <b>{totalItems}</b>
+          <span>drafts</span>
+        </div>
+        <div className="ws-stat">
+          <b>{postedItems}</b>
+          <span>posted</span>
+        </div>
+        <div className="ws-stat">
+          <b>{formatCost(totalCost)}</b>
+          <span>total cost</span>
+        </div>
       </div>
 
       <div className="desk-card">
@@ -709,11 +713,31 @@ export function AgentDetail({
                         item.primary_tweet_url || item.source_urls[0] || "",
                       )
 
+                      const statusLabel =
+                        status === "posted"
+                          ? "Posted"
+                          : status === "failed"
+                            ? "Failed"
+                            : "Draft"
+
                       return (
                         <div key={item.id} className="ws-item">
-                          <p className="ws-item-title">{item.story_summary}</p>
+                          <div className="ws-item-head">
+                            <p className="ws-item-title">{item.story_summary}</p>
+                            <span
+                              className="ws-item-status"
+                              data-status={status}
+                            >
+                              <span className="dot" />
+                              {statusLabel}
+                            </span>
+                          </div>
 
+                          <label className="flabel" htmlFor={`draft-${item.id}`}>
+                            Draft in your voice
+                          </label>
                           <textarea
+                            id={`draft-${item.id}`}
                             className="ws-textarea"
                             value={draftText}
                             onChange={(event) =>
@@ -781,25 +805,37 @@ export function AgentDetail({
                           )}
 
                           {primaryTweetId ? (
-                            <CompactTweet
-                              id={primaryTweetId}
-                              apiUrl={`/api/tweet/${primaryTweetId}`}
-                            />
-                          ) : (
-                            <div className="ws-sources">
-                              {item.source_urls.map((url, index) => (
-                                <a
-                                  key={url}
-                                  href={url}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="ws-link"
-                                  style={{ wordBreak: "break-all" }}
-                                >
-                                  Source {index + 1}
-                                </a>
-                              ))}
+                            <div className="ws-item-source">
+                              <span className="ws-item-source-label">Source</span>
+                              <CompactTweet
+                                id={primaryTweetId}
+                                apiUrl={`/api/tweet/${primaryTweetId}`}
+                              />
                             </div>
+                          ) : (
+                            item.source_urls.length > 0 && (
+                              <div className="ws-item-source">
+                                <span className="ws-item-source-label">
+                                  {item.source_urls.length === 1
+                                    ? "Source"
+                                    : "Sources"}
+                                </span>
+                                <div className="ws-sources">
+                                  {item.source_urls.map((url, index) => (
+                                    <a
+                                      key={url}
+                                      href={url}
+                                      target="_blank"
+                                      rel="noreferrer"
+                                      className="ws-link"
+                                      style={{ wordBreak: "break-all" }}
+                                    >
+                                      <b className="arr">↗</b>Source {index + 1}
+                                    </a>
+                                  ))}
+                                </div>
+                              </div>
+                            )
                           )}
                         </div>
                       )

--- a/components/loop/prompt-lab.tsx
+++ b/components/loop/prompt-lab.tsx
@@ -740,8 +740,8 @@ export function PromptLab() {
                 </span>
               </div>
               <p className="ws-results-note">
-                Review the generated news and draft previews below before posting
-                on X.
+                Review each news item and its draft below. Save the agent to post
+                or redraft on X.
               </p>
 
               <div className="ws-stories" aria-label="Agent results">
@@ -760,7 +760,10 @@ export function PromptLab() {
                         <div className="ws-story-srcs">
                           {story.sourceUrls.length > 0 ? (
                             story.sourceUrls.map((url) => (
-                              <span key={url}>↗ {url}</span>
+                              <span key={url}>
+                                <b className="arr">↗</b>
+                                {url}
+                              </span>
                             ))
                           ) : (
                             <span style={{ color: "var(--faint)" }}>
@@ -773,7 +776,8 @@ export function PromptLab() {
                       <div className="xpost">
                         <p className="xpost-body">{story.draft}</p>
                         <div className="xpost-foot">
-                          <XIcon width={15} height={15} />
+                          <XIcon width={15} height={15} fill="#FFFFFF" />
+                          <span className="chars">Draft preview</span>
                           <span className="spacer" />
                           <button
                             type="button"


### PR DESCRIPTION
Closes #26. Stacked on #28 (ft/22-ds-classes).

Reworks the create-agent/scan page (`components/loop/prompt-lab.tsx`) and the agent-detail page (`components/loop/agent-detail.tsx`) on the current design system. **Presentation-only** — no Claude Design bundle exists for these pages, so it follows the existing graphite DS.

### Changes
- **Scan page**: sentence-case results copy; story source `.arr` accent-arrow glyph; draft-preview footer uses the white `XIcon` + a `.chars` "Draft preview" label (matching the `.xpost` footer).
- **Detail page**: summary stats → four graphite `.ws-stat` cards; each run item gets a header row with a status pill (`.ws-item-status` draft/posted/failed, derived from the existing `status`), a labelled draft editor, and a grouped `.ws-item-source` block wrapping the unchanged `CompactTweet` + source links.
- `app/workspace.css`: presentation-only additions (`.ws-stat`, `.ws-item-head`, `.ws-item-status`, `.ws-item-source`, `.ws-sources .arr`), all `.workspace`-scoped.

### Behavior contracts preserved (verified)
`git diff` confirms **zero** changes to any `fetch` call, request body key, API route, or HTTP method. The run → preview → save → post/redraft pipeline, all body keys (`name`/`handles`/`monitoringDescription`/`draftingInstructions`/`stories`/`metrics`/`finalText`), 409 dup-name handling, stream-event reducers, story toggle, unsaved-changes guard, and auth/connect-x gating are all untouched.

One presentation-equivalent render-condition change: the non-tweet sources block now guards on `source_urls.length > 0` (previously rendered an empty bordered div). Link hrefs/targets are byte-identical.

### Verification
- `pnpm build` ✅ · `pnpm lint` ✅ (no issues).
- Visual + live scan/post verification deferred to the #27 end-to-end pass (no live Grok/X calls in this sprint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)